### PR TITLE
Fix scaling of SVG Edit

### DIFF
--- a/image_occlusion_2/image_occlusion.py
+++ b/image_occlusion_2/image_occlusion.py
@@ -271,9 +271,8 @@ class ImageOcc_Editor(QWidget):
                                                    label=False)
 
         vbox = QVBoxLayout()
-        vbox.addStretch(1)
         vbox.addLayout(header_hbox)
-        vbox.addWidget(self.svg_edit)
+        vbox.addWidget(self.svg_edit, 1)
         vbox.addLayout(footer_hbox)
         vbox.addLayout(tags_hbox)
         vbox.addWidget(deck_container)


### PR DESCRIPTION
This fixes an issue where resizing the image occlusion window doesn't
resize the SVG Edit container. This makes image occlusion more usable
for large images and (for me) on high DPI screens.
